### PR TITLE
Update repo name and fix waiter script

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -83,8 +83,8 @@ jobs:
       - name: Run Docker image
         run: |
           docker run --rm \
-          -e REPO_OWNER=Enterprise-CMCS \
-          -e REPO_NAME=github-actions-runner-aws \
+          -e REPO_OWNER=${{ github.repository_owner }} \
+          -e REPO_NAME=$(basename ${{ github.repository }}) \
           -e PERSONAL_ACCESS_TOKEN=${{ secrets.SERVICE_ACCOUNT_GITHUB_TOKEN }} \
           -e RUNNER_UUID=${{ needs.set-runner-uuid.outputs.runner-uuid }} \
           ${{ env.SHA_TAG }}
@@ -97,12 +97,25 @@ jobs:
     steps:
       - name: Poll the GitHub Actions API until the runner is registered and online
         run: |
+          response_file=$(mktemp)
           until \
-            curl -s \
+            status=$(curl -s \
               -H "Accept: application/vnd.github.v3+json" \
               -u robot-mac-fc:${{ secrets.SERVICE_ACCOUNT_GITHUB_TOKEN }} \
-              https://api.github.com/repos/Enterprise-CMCS/github-actions-runner-aws/actions/runners \
-            | jq -e '.runners | .[] | select(.name == "${{ needs.set-runner-uuid.outputs.runner-uuid }}") | .status == "online"' >/dev/null
+              -o $response_file \
+              -w "%{http_code}" \
+              --url https://api.github.com/repos/${{ github.repository }}/actions/runners
+            )
+
+            if [ $? -ne 0 ] || [ $status -ne 200 ]; then
+              echo "error getting runner status from GitHub"
+              echo "curl exited with code $?"
+              echo "response status: $status"
+              echo "response body: $(cat $response_file)"
+              exit 1
+            fi
+
+            cat $response_file | jq -e '.runners | .[] | select(.name == "${{ needs.set-runner-uuid.outputs.runner-uuid }}") | .status == "online"' >/dev/null
           do
             echo "Waiting for runner ${{ needs.set-runner-uuid.outputs.runner-uuid }} to be ready" && sleep 10
           done


### PR DESCRIPTION
This change updates the `docker-build` workflow to work with the new repo name (`github-actions-runner-aws` -> `mac-fc-github-actions-runner-aws`).  It also adds some error checking to the script that waits for the runner to be registered before proceeding to the runner test job. This fixes a bug where if curl exited with a non-zero code or the GitHub API returned a non-200 status, the waiter would still wait, rather than exiting with a non-zero code as it should. 

Manual testing:
- ran the workflow with the old repo name. This returned a `301` and thus triggered the new error-handling branch
- made sure the workflow ran successfully with the new repo name