### PR TITLE
Update Actions Runner Version to 2.306.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apk add --update --no-cache \
     tar \
     ca-certificates
 
-ARG ACTIONS_VERSION="2.304.0"
+ARG ACTIONS_VERSION="2.306.0"
 
 RUN \
     # install runner


### PR DESCRIPTION
Automated update from Github Actions Runner version 2.304.0 to version 2.306.0
Release Notes: https://github.com/actions/runner/releases/tag/v2.306.0