### PR TITLE
allow IAM OIDC role permissions policy to be json string

### DIFF
--- a/github-oidc/terraform/github-oidc.tf
+++ b/github-oidc/terraform/github-oidc.tf
@@ -44,5 +44,5 @@ resource "aws_iam_role" "github_actions_oidc" {
 resource "aws_iam_role_policy" "github_actions_permissions" {
   name   = "github-actions-permissions"
   role   = aws_iam_role.github_actions_oidc.id
-  policy = file("${path.root}/${var.github_actions_permissions_policy_json_path}")
+  policy = var.policy_read_from_file ? file("${path.root}/${var.github_actions_permissions_policy_json_path}") : var.policy_json
 }

--- a/github-oidc/terraform/variables.tf
+++ b/github-oidc/terraform/variables.tf
@@ -33,7 +33,7 @@ variable "policy_read_from_file" {
 }
 
 variable "policy_json" {
-  description = "The IAM role policy is in the format of a JSON string"
+  description = "The IAM role policy in the format of a JSON string"
   type        = string
   default     = ""
 }

--- a/github-oidc/terraform/variables.tf
+++ b/github-oidc/terraform/variables.tf
@@ -25,3 +25,15 @@ variable "add_read_only_access" {
   type        = bool
   default     = false
 }
+
+variable "policy_read_from_file" {
+  description = "true if the IAM role policy is read from a file, else false"
+  type        = bool
+  default     = true
+}
+
+variable "policy_json" {
+  description = "The IAM role policy is in the format of a JSON string"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
https://jiraent.cms.gov/browse/CMCSMACD-1608

This PR allows the input policy that defines the IAM OIDC role permissions to be a JSON string and a path to a filename.

With this change, the policy can be specified as a policy document, that can be parameterized for different regions and accounts.

Tested:
I verified that with this change, the Kong smoke-test workflow can successfully run the credential action:
aws-actions/configure-aws-credentials@v3
and run all steps following the credential action
which means the change did not affect the current workflows