### PR TITLE
Pin version of Playwright base image

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -21,6 +21,6 @@ jobs:
       ./.github/workflows/_docker-build.yml
     with:
       dockerfile: playwright.Dockerfile
-      feature-branch-image-tag: playwright
-      default-branch-image-tag: playwright
+      feature-branch-image-tag: playwright-v1.38.0
+      default-branch-image-tag: playwright-v1.38.0
     secrets: inherit

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This module uses an existing ECR repository in AWS, and so does not provision on
 ## Runner Dockerfiles
 
 - `latest.Dockerfile`: A minimal runner image based on Ubuntu. Reference this image with the `latest` image tag
-- `playwright.Dockerfile`: An image using the [`playwright:focal` base image](https://mcr.microsoft.com/en-us/product/playwright/about) for Playwright dependencies. Reference this image with the `playwright` image tag
+- `playwright.Dockerfile`: An image using the [`playwright:focal` base image](https://mcr.microsoft.com/en-us/product/playwright/about) for Playwright dependencies. Reference this image with the `playwright-v{semver}` image tag, where `{semver}` is the version of the Playwright base image defined in the `playwright.Dockerfile`
 
 The current version of the runner is stored in `docker.env` as `ACTIONS_VERSION`. To build the Dockerfiles locally, you must first export this environment variable, then tell Docker to use it as a [build argument from the environment](https://docs.docker.com/engine/reference/commandline/build/#build-arg), like so:
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This module uses an existing ECR repository in AWS, and so does not provision on
 ## Runner Dockerfiles
 
 - `latest.Dockerfile`: A minimal runner image based on Ubuntu. Reference this image with the `latest` image tag
-- `playwright.Dockerfile`: An image using the [`playwright:focal` base image](https://mcr.microsoft.com/en-us/product/playwright/about) for Playwright dependencies. Reference this image with the `playwright-v{semver}` image tag, where `{semver}` is the version of the Playwright base image defined in the `playwright.Dockerfile`
+- `playwright.Dockerfile`: An image using the [`playwright:focal` base image](https://mcr.microsoft.com/en-us/product/playwright/about) for Playwright dependencies. Reference this image with the `playwright-v{semver}` image tag, where `{semver}` is the semantic version of the Playwright base image defined in the `playwright.Dockerfile`
 
 The current version of the runner is stored in `docker.env` as `ACTIONS_VERSION`. To build the Dockerfiles locally, you must first export this environment variable, then tell Docker to use it as a [build argument from the environment](https://docs.docker.com/engine/reference/commandline/build/#build-arg), like so:
 

--- a/playwright.Dockerfile
+++ b/playwright.Dockerfile
@@ -14,7 +14,7 @@ RUN \
     && mkdir runner \
     && tar xzf "actions-runner-linux-x64-${ACTIONS_VERSION}.tar.gz" --directory ./runner
 
-FROM mcr.microsoft.com/playwright:focal
+FROM mcr.microsoft.com/playwright:v1.38.0-focal
 
 RUN groupadd "runner" && useradd -g "runner" --shell /bin/bash "runner" \
     && mkdir -p "/home/runner" \


### PR DESCRIPTION
This is a fix for https://github.com/Enterprise-CMCS/mac-fc-github-actions-runner-aws/pull/174. It pins the Playwright base image at 1.38.0 and renames the tag for the Playwright image so that it's clear what version is baked into the image. This is needed because if the version of the Playwright dependencies (in the image) and the Playwright runner are different, the tests won't run. I also updated the README to reflect this.

Tests:
- built the image locally
- built and pushed, and successfully ran tests on the image from the ProfessorMAC repo (which specifies 1.38.0)