### PR TITLE
change version to lowest acceptable version

### DIFF
--- a/github-oidc/terraform/versions.tf
+++ b/github-oidc/terraform/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = ">= 4.0"
     }
   }
 }


### PR DESCRIPTION
Per best practices documented here https://developer.hashicorp.com/terraform/language/providers/requirements#best-practices-for-provider-versions, a module to be shared should specify the minimum acceptable version. Consumers of the module should specify the highest acceptable version. This protects the consumers from breaking updates to the consumed module.

This PR lowers the version of the AWS provider in the consumed module to `>= 4.0`.