### PR TITLE
add missing ecr to state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ test_env
 
 .terraform.lock.hcl
 .terraform
+terraform.tfstate.backup

--- a/terraform.tfstate
+++ b/terraform.tfstate
@@ -1,7 +1,7 @@
 {
   "version": 4,
   "terraform_version": "1.5.2",
-  "serial": 1,
+  "serial": 5,
   "lineage": "ff2ff791-3ff9-c81c-c029-9e0e46f5f045",
   "outputs": {},
   "resources": [
@@ -87,6 +87,28 @@
     },
     {
       "mode": "managed",
+      "type": "aws_ecr_lifecycle_policy",
+      "name": "github_actions_runner",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "github-actions-runner",
+            "policy": "{\"rules\":[{\"action\":{\"type\":\"expire\"},\"description\":\"Keep last 500 images\",\"rulePriority\":10,\"selection\":{\"countNumber\":500,\"countType\":\"imageCountMoreThan\",\"tagStatus\":\"any\"}}]}",
+            "registry_id": "037370603820",
+            "repository": "github-actions-runner"
+          },
+          "sensitive_attributes": [],
+          "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjAifQ==",
+          "dependencies": [
+            "aws_ecr_repository.github_actions_runner"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
       "type": "aws_ecr_repository",
       "name": "github_actions_runner",
       "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
@@ -122,6 +144,29 @@
           },
           "sensitive_attributes": [],
           "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiZGVsZXRlIjoxMjAwMDAwMDAwMDAwfSwic2NoZW1hX3ZlcnNpb24iOiIwIn0="
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_ecr_repository_policy",
+      "name": "github_actions_runner",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "github-actions-runner",
+            "policy": "{\"Statement\":[{\"Action\":[\"ecr:ListImages\",\"ecr:GetDownloadUrlForLayer\",\"ecr:GetAuthorizationToken\",\"ecr:DescribeImages\",\"ecr:BatchGetImage\",\"ecr:BatchCheckLayerAvailability\"],\"Condition\":{\"StringLike\":{\"aws:PrincipalOrgID\":\"o-ry4nhh9eic\"}},\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"*\"},\"Sid\":\"OrganizationECRReadOnly\"}],\"Version\":\"2012-10-17\"}",
+            "registry_id": "037370603820",
+            "repository": "github-actions-runner"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "aws_ecr_repository.github_actions_runner",
+            "data.aws_iam_policy_document.ecr_perms_ro_organization"
+          ]
         }
       ]
     }


### PR DESCRIPTION
This PR imports 2 ECR policies into this repo:
terraform import aws_ecr_lifecycle_policy.github_actions_runner github-actions-runner
terraform import aws_ecr_repository_policy.github_actions_runner github-actions-runner

I unintentionally left these imports out of PR **.

Tested:
After importing, I ran `terraform plan/apply` in the repo and the only change was related to removing the Sid GithubActionsPermissions assigned to a IAM user created for github actions.
