### PR TITLE
add default tags to github-actions-runner IAM and ECR resources

### DIFF
--- a/terraform/dev/account/terraform.tfstate
+++ b/terraform/dev/account/terraform.tfstate
@@ -1,7 +1,7 @@
 {
   "version": 4,
   "terraform_version": "1.5.2",
-  "serial": 8,
+  "serial": 18,
   "lineage": "ff2ff791-3ff9-c81c-c029-9e0e46f5f045",
   "outputs": {},
   "resources": [
@@ -272,12 +272,19 @@
               "Automation": "Terraform"
             },
             "tags_all": {
-              "Automation": "Terraform"
+              "Application": "mac-fc-github-actions-runner",
+              "Automated": "Terraform",
+              "Automation": "Terraform",
+              "Business": "MACBIS",
+              "Environment": "dev",
+              "Maintainer": "cms-macfc+archive@corbalt.com",
+              "Owner": "cms-macfc+archive@corbalt.com",
+              "stack": "dev"
             },
             "timeouts": null
           },
           "sensitive_attributes": [],
-          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiZGVsZXRlIjoxMjAwMDAwMDAwMDAwfSwic2NoZW1hX3ZlcnNpb24iOiIwIn0="
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiZGVsZXRlIjoxMjAwMDAwMDAwMDAwfX0="
         }
       ]
     },
@@ -299,7 +306,8 @@
           "private": "bnVsbA==",
           "dependencies": [
             "aws_ecr_repository.github_actions_runner",
-            "data.aws_iam_policy_document.ecr_perms_ro_organization"
+            "data.aws_iam_policy_document.ecr_perms_ro_organization",
+            "data.aws_organizations_organization.cmsgov"
           ]
         }
       ]
@@ -319,7 +327,15 @@
             ],
             "id": "arn:aws:iam::037370603820:oidc-provider/token.actions.githubusercontent.com",
             "tags": {},
-            "tags_all": {},
+            "tags_all": {
+              "Application": "mac-fc-github-actions-runner",
+              "Automated": "Terraform",
+              "Business": "MACBIS",
+              "Environment": "dev",
+              "Maintainer": "cms-macfc+archive@corbalt.com",
+              "Owner": "cms-macfc+archive@corbalt.com",
+              "stack": "dev"
+            },
             "thumbprint_list": [
               "6938fd4d98bab03faadb97b34396831e3780aea1",
               "1c58a3a8518e8759bf075b76b750d4f2df264fcd"
@@ -327,7 +343,7 @@
             "url": "token.actions.githubusercontent.com"
           },
           "sensitive_attributes": [],
-          "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjAifQ=="
+          "private": "bnVsbA=="
         }
       ]
     },
@@ -361,11 +377,24 @@
             "path": "/delegatedadmin/developer/",
             "permissions_boundary": "arn:aws:iam::037370603820:policy/cms-cloud-admin/developer-boundary-policy",
             "tags": {},
-            "tags_all": {},
+            "tags_all": {
+              "Application": "mac-fc-github-actions-runner",
+              "Automated": "Terraform",
+              "Business": "MACBIS",
+              "Environment": "dev",
+              "Maintainer": "cms-macfc+archive@corbalt.com",
+              "Owner": "cms-macfc+archive@corbalt.com",
+              "stack": "dev"
+            },
             "unique_id": "AROAQRM3WFEWILEWHO6PD"
           },
           "sensitive_attributes": [],
-          "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjAifQ=="
+          "private": "bnVsbA==",
+          "dependencies": [
+            "aws_iam_openid_connect_provider.github_actions",
+            "data.aws_caller_identity.current",
+            "data.aws_iam_policy_document.github_actions_assume_role"
+          ]
         }
       ]
     },
@@ -385,7 +414,14 @@
             "role": "github-actions-oidc"
           },
           "sensitive_attributes": [],
-          "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjAifQ=="
+          "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjAifQ==",
+          "dependencies": [
+            "aws_iam_openid_connect_provider.github_actions",
+            "aws_iam_role.github_actions_oidc",
+            "data.aws_caller_identity.current",
+            "data.aws_iam_policy_document.github_actions_assume_role",
+            "data.aws_iam_policy_document.github_actions_permissions"
+          ]
         }
       ]
     }

--- a/terraform/dev/account/versions.tf
+++ b/terraform/dev/account/versions.tf
@@ -11,4 +11,16 @@ terraform {
 
 provider "aws" {
   allowed_account_ids = ["037370603820"]
+
+  default_tags {
+    tags = {
+      Maintainer  = "cms-macfc+archive@corbalt.com"
+      Owner       = "cms-macfc+archive@corbalt.com"
+      Environment = "dev"
+      Application = "mac-fc-github-actions-runner"
+      Business    = "MACBIS"
+      Automated   = "Terraform"
+      stack       = "dev"
+    }
+  }
 }


### PR DESCRIPTION
https://jiraent.cms.gov/browse/CMCSMACD-1873

Set default tags for ecr and IAM identity provider, and role.

Tested:
successfully ran `terraform apply` 
then `terraform plan` showed No Changes
verified tags in IAM console and ECR console