### PR TITLE
enable scan on push

### DIFF
--- a/terraform/dev/account/ecr.tf
+++ b/terraform/dev/account/ecr.tf
@@ -2,7 +2,7 @@ data "aws_organizations_organization" "cmsgov" {}
 
 resource "aws_ecr_repository" "github_actions_runner" {
   name                 = "github-actions-runner"
-  image_tag_mutability = "IMMUTABLE"
+  image_tag_mutability = "MUTABLE"
 
   image_scanning_configuration {
     scan_on_push = true

--- a/terraform/dev/account/ecr.tf
+++ b/terraform/dev/account/ecr.tf
@@ -1,7 +1,12 @@
 data "aws_organizations_organization" "cmsgov" {}
 
 resource "aws_ecr_repository" "github_actions_runner" {
-  name = "github-actions-runner"
+  name                 = "github-actions-runner"
+  image_tag_mutability = "IMMUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
 
   tags = {
     Automation = "Terraform"


### PR DESCRIPTION
https://jiraent.cms.gov/browse/CMCSMACD-1862

for ECR repo:
enable scan on push

Note: tag must be set to MUTABLE (the default) since the repo tags each build with a SHA and `latest`

Tested:
Successfully ran `terraform apply`.
Saw in ECR console that playwright has 87 vulnerabilities (all MEDIUM and lower)