### PR TITLE
revert ubuntu to 23.10

### DIFF
--- a/latest.Dockerfile
+++ b/latest.Dockerfile
@@ -14,7 +14,7 @@ RUN \
     && mkdir runner \
     && tar xzf "actions-runner-linux-x64-${ACTIONS_VERSION}.tar.gz" --directory ./runner
 
-FROM ubuntu:24.04
+FROM ubuntu:23.10
 
 RUN groupadd "runner" && useradd -g "runner" --shell /bin/bash "runner" \
     && mkdir -p "/home/runner" \


### PR DESCRIPTION
https://jiraent.cms.gov/browse/CMCSMACD-1927

This PR reverts the self-hosted runner OS to ubuntu version 23.10 (from 24.04).
The reason is that 24.04 is a pre-released version, which confused dependabot.

Tested:
All automated tests passed.