### PR TITLE
Update trivyignore

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,11 +1,21 @@
 # accept the risk of the internal Node.JS libraries used by the runner.
 
+# CVE-2021-3807
+# CVE-2021-3918
+# CVE-2021-44906
+# CVE-2022-3517
+# CVE-2022-24999
+# CVE-2022-25881
+# CVE-2022-38900
 CVE-2022-25883
 CVE-2024-28863
 CVE-2024-29415
 
 # accept the risk of internal dotnet-core dependencies for the runner
 
+# CVE-2018-8292
 CVE-2019-0981
 CVE-2019-0980
 CVE-2024-38095
+CVE-2023-44487
+CVE-2023-5217

--- a/.trivyignore
+++ b/.trivyignore
@@ -3,8 +3,9 @@
 CVE-2022-25883
 CVE-2024-28863
 CVE-2024-29415
-CVE-2023-42282
 
 # accept the risk of internal dotnet-core dependencies for the runner
 
+CVE-2019-0981
+CVE-2019-0980
 CVE-2024-38095

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,19 +1,11 @@
 # accept the risk of the internal Node.JS libraries used by the runner.
 
-# CVE-2021-3807
-# CVE-2021-3918
-# CVE-2021-44906
-# CVE-2022-3517
-# CVE-2022-24999
-# CVE-2022-25881
-# CVE-2022-38900
 CVE-2022-25883
 CVE-2024-28863
 CVE-2024-29415
 
 # accept the risk of internal dotnet-core dependencies for the runner
 
-# CVE-2018-8292
 CVE-2019-0981
 CVE-2019-0980
 CVE-2024-38095

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,17 +1,10 @@
 # accept the risk of the internal Node.JS libraries used by the runner.
 
-CVE-2021-3807
-CVE-2021-3918
-CVE-2021-44906
-CVE-2022-3517
-CVE-2022-24999
-CVE-2022-25881
-CVE-2022-38900
+CVE-2022-25883
+CVE-2024-28863
+CVE-2024-29415
+CVE-2023-42282
 
 # accept the risk of internal dotnet-core dependencies for the runner
 
-CVE-2018-8292
-CVE-2019-0981
-CVE-2019-0980
-CVE-2019-0820
 CVE-2024-38095


### PR DESCRIPTION
We have to ignore vulnerabilities that are baked into the runner software and the playwright image, which we don't control.

This change:
- removes CVEs that are no longer vulnerabilities
- adds some new ones


Testing: 
- our CI tests this by running Trivy