### PR TITLE
Fix Trivy rate limit error by pulling vulnerability DB from ECR

### DIFF
--- a/.github/workflows/_docker-build.yml
+++ b/.github/workflows/_docker-build.yml
@@ -86,15 +86,10 @@ jobs:
           load: true # this loads the image to the current docker instance so it can be referenced by tag in the subsequent steps: https://docs.docker.com/engine/reference/commandline/buildx_build/#docker
           provenance: false # the default behavior adds an 'image index' which clutters up ECR, see https://github.com/docker/buildx/issues/1533
 
-      # - name: Install Trivy vulnerability scanner
-      #   uses: aquasecurity/setup-trivy@v0.2.2
-      #   with:
-      #     cache: true
-      #     token: ${{ secrets.SERVICE_ACCOUNT_GITHUB_TOKEN }}
-
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.28.0
         env:
+          # avoid GHCR rate limits, see https://github.com/aquasecurity/trivy-db/pull/440 and https://github.com/aquasecurity/trivy-action/issues/389
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
         with:
           image-ref: ${{ steps.set-image-tag-with-repo.outputs.image-tag-with-repo }}

--- a/.github/workflows/_docker-build.yml
+++ b/.github/workflows/_docker-build.yml
@@ -86,10 +86,16 @@ jobs:
           load: true # this loads the image to the current docker instance so it can be referenced by tag in the subsequent steps: https://docs.docker.com/engine/reference/commandline/buildx_build/#docker
           provenance: false # the default behavior adds an 'image index' which clutters up ECR, see https://github.com/docker/buildx/issues/1533
 
+      - name: Install Trivy vulnerability scanner
+        uses: aquasecurity/setup-trivy@v0.2.2
+        with:
+          cache: true
+          token: ${{ secrets.SERVICE_ACCOUNT_GITHUB_TOKEN }}
+
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.28.0
         with:
-          github-pat: ${{ secrets.SERVICE_ACCOUNT_GITHUB_TOKEN }}
+          skip-setup-trivy: true
           image-ref: ${{ steps.set-image-tag-with-repo.outputs.image-tag-with-repo }}
           format: "table"
           exit-code: "1"

--- a/.github/workflows/_docker-build.yml
+++ b/.github/workflows/_docker-build.yml
@@ -87,8 +87,9 @@ jobs:
           provenance: false # the default behavior adds an 'image index' which clutters up ECR, see https://github.com/docker/buildx/issues/1533
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.28.0
         with:
+          github-pat: ${{ secrets.SERVICE_ACCOUNT_GITHUB_TOKEN }}
           image-ref: ${{ steps.set-image-tag-with-repo.outputs.image-tag-with-repo }}
           format: "table"
           exit-code: "1"

--- a/.github/workflows/_docker-build.yml
+++ b/.github/workflows/_docker-build.yml
@@ -86,16 +86,17 @@ jobs:
           load: true # this loads the image to the current docker instance so it can be referenced by tag in the subsequent steps: https://docs.docker.com/engine/reference/commandline/buildx_build/#docker
           provenance: false # the default behavior adds an 'image index' which clutters up ECR, see https://github.com/docker/buildx/issues/1533
 
-      - name: Install Trivy vulnerability scanner
-        uses: aquasecurity/setup-trivy@v0.2.2
-        with:
-          cache: true
-          token: ${{ secrets.SERVICE_ACCOUNT_GITHUB_TOKEN }}
+      # - name: Install Trivy vulnerability scanner
+      #   uses: aquasecurity/setup-trivy@v0.2.2
+      #   with:
+      #     cache: true
+      #     token: ${{ secrets.SERVICE_ACCOUNT_GITHUB_TOKEN }}
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.28.0
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
         with:
-          skip-setup-trivy: true
           image-ref: ${{ steps.set-image-tag-with-repo.outputs.image-tag-with-repo }}
           format: "table"
           exit-code: "1"


### PR DESCRIPTION
We started seeing rate limit errors for Trivy when pulling the vulnerability DB from GHCR. It's a well-documented issue: https://github.com/aquasecurity/trivy-action/issues/389

This change adopts a recommended workaround for that issue: Trivy started[ pushing the DB to ECR](https://github.com/aquasecurity/trivy-db/pull/440), and switching to that source seems to have fixed the rate-limiting problem

Testing: ran the pipeline and it succeeded. 