### PR TITLE
Bump ubuntu base image to 25.04 for latest image; update trivyignores

### DIFF
--- a/.github/workflows/_docker-build.yml
+++ b/.github/workflows/_docker-build.yml
@@ -7,6 +7,10 @@ on:
         description: "Path to the Dockerfile to build"
         type: string
         default: "latest.Dockerfile"
+      trivyignore:
+        description: "Path to trivyignore file"
+        type: string
+        default: ".trivyignore-latest"
       feature-branch-image-tag:
         description: "Tag to apply to the Docker image when workflow runs on a feature branch"
         type: string
@@ -98,6 +102,7 @@ jobs:
           ignore-unfixed: true
           vuln-type: "os,library"
           severity: "CRITICAL,HIGH"
+          trivyignores: ${{ inputs.trivyignore }}
 
       - name: Run Dockle image linter
         uses: hands-lab/dockle-action@v1

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -21,6 +21,7 @@ jobs:
       ./.github/workflows/_docker-build.yml
     with:
       dockerfile: playwright.Dockerfile
+      trivyignore: .trivyignore-playwright
       feature-branch-image-tag: playwright-v1.38.0
       default-branch-image-tag: playwright-v1.38.0
     secrets: inherit

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,5 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
       - uses: actions/setup-python@v5.2.0
       - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,6 +9,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: "1.5.2"
+          terraform_version: "~>1.5.2" # match the version constraint in versions.tf
       - uses: actions/setup-python@v5.2.0
       - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -8,5 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform-version: "1.5.2"
       - uses: actions/setup-python@v5.2.0
       - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,6 +9,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: hashicorp/setup-terraform@v3
         with:
-          terraform-version: "1.5.2"
+          terraform_version: "1.5.2"
       - uses: actions/setup-python@v5.2.0
       - uses: pre-commit/action@v3.0.0

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,13 +1,14 @@
 # accept the risk of the internal Node.JS libraries used by the runner.
 
-CVE-2022-25883
-CVE-2024-28863
-CVE-2024-29415
+CVE-2024-21538
+<!-- CVE-2022-25883 -->
+<!-- CVE-2024-28863 -->
+<!-- CVE-2024-29415 -->
 
 # accept the risk of internal dotnet-core dependencies for the runner
 
-CVE-2019-0981
-CVE-2019-0980
+<!-- CVE-2019-0981 -->
+<!-- CVE-2019-0980 -->
 CVE-2024-38095
-CVE-2023-44487
-CVE-2023-5217
+<!-- CVE-2023-44487
+CVE-2023-5217 -->

--- a/.trivyignore-latest
+++ b/.trivyignore-latest
@@ -1,14 +1,8 @@
 # accept the risk of the internal Node.JS libraries used by the runner.
 
 CVE-2024-21538
-<!-- CVE-2022-25883 -->
-<!-- CVE-2024-28863 -->
-<!-- CVE-2024-29415 -->
 
 # accept the risk of internal dotnet-core dependencies for the runner
 
-<!-- CVE-2019-0981 -->
-<!-- CVE-2019-0980 -->
 CVE-2024-38095
-<!-- CVE-2023-44487
-CVE-2023-5217 -->
+

--- a/.trivyignore-playwright
+++ b/.trivyignore-playwright
@@ -1,0 +1,12 @@
+# accept the risk of the Microsoft Playwright image
+
+CVE-2023-44487
+CVE-2023-5217
+
+# accept the risk of the internal Node.JS libraries used by the runner.
+
+CVE-2024-21538
+
+# accept the risk of internal dotnet-core dependencies for the runner
+
+CVE-2024-38095

--- a/latest.Dockerfile
+++ b/latest.Dockerfile
@@ -23,7 +23,7 @@ RUN groupadd "runner" && useradd -g "runner" --shell /bin/bash "runner" \
 COPY --from=install /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=install ./runner /home/runner
 
-# install libicu for Ubuntu 24.04
+# install libicu for Ubuntu 25.04
 # https://github.com/actions/runner/issues/3150
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/latest.Dockerfile
+++ b/latest.Dockerfile
@@ -14,7 +14,7 @@ RUN \
     && mkdir runner \
     && tar xzf "actions-runner-linux-x64-${ACTIONS_VERSION}.tar.gz" --directory ./runner
 
-FROM ubuntu:24.04
+FROM ubuntu:25.04
 
 RUN groupadd "runner" && useradd -g "runner" --shell /bin/bash "runner" \
     && mkdir -p "/home/runner" \


### PR DESCRIPTION
This housekeeping change:

- Bumps the Ubuntu base image version in the `latest.Dockerfile` to address CVE-2024-53103
- Splits the single trivyignore file into two, one for the `latest` image and one for the `playwright` image
  - I did this so it's easier for consumers of the images to see what vulnerabilities we need to accept since they are baked in to the base images or software we use
- Installs Terraform in the pre-commit workflow since the `ubuntu-latest` GitHub runner [is now 24.04](https://github.com/actions/runner-images/issues/10636) and Terraform was "removed from the Ubuntu 24.04 image due to maintenance reasons."

Testing: 
- ran Trivy locally
- the build-push workflow ran successfully