### PR TITLE
Address Dockle finding

### DIFF
--- a/latest.Dockerfile
+++ b/latest.Dockerfile
@@ -42,6 +42,10 @@ RUN apt-get update \
     unzip \
     && rm -rf /var/lib/apt/lists
 
+# Remove setuid and setgid permissions after all package installations to addresss
+# https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#cis-di-0008
+RUN find / -path /proc -prune -o -perm /6000 -type f -exec chmod a-s {} + || true
+
 WORKDIR /home/runner
 USER runner
 

--- a/latest.Dockerfile
+++ b/latest.Dockerfile
@@ -42,7 +42,7 @@ RUN apt-get update \
     unzip \
     && rm -rf /var/lib/apt/lists
 
-# Remove setuid and setgid permissions after all package installations to addresss
+# Remove setuid and setgid permissions after all package installations to address
 # https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#cis-di-0008
 RUN find / -path /proc -prune -o -perm /6000 -type f -exec chmod a-s {} + || true
 


### PR DESCRIPTION
Address https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#cis-di-0008 by removing all `setuid` and `setgid` permissions after installing packages.

Testing:
- ran Dockle locally and the finding wasn't found
- ran build workflow, it succeeded and the finding wasn't found

This is an esoteric corner of image security, so here's a background link as well as a summary and breakdown of the command (both courtesy of Claude): 

https://www.scaler.com/topics/special-permissions-in-linux/

> In Unix-like systems, every file has a set of permissions that control who can read, write, and execute it. But there's an additional layer - special permission bits called SUID (Set User ID) and SGID (Set Group ID). Think of these as temporary privilege escalation switches.
When the SUID bit is set on an executable file, anyone who runs that program will temporarily gain the permissions of the file's owner while the program is running. Similarly, the SGID bit grants the permissions of the file's group. These bits are represented by an 's' in the permission string when you run 'ls -l', appearing where you'd normally see 'x' for execute permissions.
Here's a concrete example: Consider the 'ping' command, which is typically owned by root and has the SUID bit set. When a regular user runs ping, they temporarily get root privileges because ping needs these elevated permissions to create raw network packets. Without SUID, regular users couldn't use ping at all.
However, these bits can become dangerous security vulnerabilities in several ways:

> If an attacker finds a bug in an SUID program, they might be able to trick it into doing something with its elevated privileges that it wasn't meant to do. This is particularly dangerous because the program runs with root permissions.
If an SUID/SGID file is writable by other users or has incorrect permissions, an attacker could modify the program to include malicious code that would then run with elevated privileges.
Some SUID/SGID programs might have been installed unnecessarily, creating needless security risks. Every SUID/SGID program increases what security professionals call the "attack surface" - the number of potential ways an attacker could compromise the system.

> In container environments, these risks become even more relevant because containers often run with reduced privileges for security. Having unnecessary SUID/SGID binaries in a container image could provide an attacker with a way to escalate privileges within the container, potentially leading to container breakout or other security issues.

Here's the breakdown of the command:

The command `find / -path /proc -prune -o -perm /6000 -type f -exec chmod a-s {} + || true` consists of several key components that work together to find and modify files with special permissions. Let's examine each part:

1. `find /`  
   This initiates a search starting from the root directory (/), which means it will scan the entire filesystem hierarchy.

2. `-path /proc -prune`  
   This tells find to skip the /proc directory. The /proc filesystem is virtual and contains process information that we don't need to scan. Pruning it improves efficiency and avoids potential errors.

3. `-o`  
   This is the OR operator. It connects our instruction to prune /proc with the rest of our search conditions. Think of it as saying "either prune /proc OR process this file according to our other conditions."

4. `-perm /6000`  
   This matches files with SUID (4000) and/or SGID (2000) bits set. The forward slash means we're matching files that have either or both bits set, not just files that have exactly these permissions.

5. `-type f`  
   This restricts our search to regular files only. We're not interested in directories, symbolic links, or other special file types when dealing with SUID/SGID permissions.

6. `-exec chmod a-s {} +`  
   This executes the chmod command on our matched files:
   * `a-s` unsets the SUID and SGID bits for all users
   * `{}` is a placeholder that gets replaced with the filenames find discovers
   * The `+` at the end means find will pass multiple filenames to chmod at once, making the operation more efficient than processing one file at a time

7. `|| true`  
   This ensures our command returns a success status (exit code 0) even if some operations fail. We want to continue execution even if some permissions can't be modified.

