### PR TITLE
Scan and fix MEDIUM Trivy vulnerabilities for latest image

### DIFF
--- a/.github/workflows/_docker-build.yml
+++ b/.github/workflows/_docker-build.yml
@@ -26,6 +26,7 @@ on:
 
 permissions:
   id-token: write
+  contents: read
 
 jobs:
   set-runner-uuid:

--- a/.github/workflows/_docker-build.yml
+++ b/.github/workflows/_docker-build.yml
@@ -101,7 +101,7 @@ jobs:
           exit-code: "1"
           ignore-unfixed: true
           vuln-type: "os,library"
-          severity: "CRITICAL,HIGH"
+          severity: "CRITICAL,HIGH,MEDIUM"
           trivyignores: ${{ inputs.trivyignore }}
 
       - name: Run Dockle image linter

--- a/.github/workflows/_docker-build.yml
+++ b/.github/workflows/_docker-build.yml
@@ -19,6 +19,10 @@ on:
         description: "Tag to apply to the Docker image when workflow runs on the default branch"
         type: string
         default: "latest"
+      trivy-severity:
+        description: "Severity levels for Trivy scanner"
+        type: string
+        default: "CRITICAL,HIGH,MEDIUM"
 
 permissions:
   id-token: write
@@ -101,7 +105,7 @@ jobs:
           exit-code: "1"
           ignore-unfixed: true
           vuln-type: "os,library"
-          severity: "CRITICAL,HIGH,MEDIUM"
+          severity: ${{ inputs.trivy-severity }}
           trivyignores: ${{ inputs.trivyignore }}
 
       - name: Run Dockle image linter

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -24,4 +24,5 @@ jobs:
       trivyignore: .trivyignore-playwright
       feature-branch-image-tag: playwright-v1.38.0
       default-branch-image-tag: playwright-v1.38.0
+      trivy-severity: "CRITICAL,HIGH"
     secrets: inherit

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   id-token: write
+  contents: read
 
 jobs:
   latest:

--- a/latest.Dockerfile
+++ b/latest.Dockerfile
@@ -14,7 +14,7 @@ RUN \
     && mkdir runner \
     && tar xzf "actions-runner-linux-x64-${ACTIONS_VERSION}.tar.gz" --directory ./runner
 
-FROM ubuntu:25.04
+FROM ubuntu:25.10
 
 RUN groupadd "runner" && useradd -g "runner" --shell /bin/bash "runner" \
     && mkdir -p "/home/runner" \
@@ -23,12 +23,13 @@ RUN groupadd "runner" && useradd -g "runner" --shell /bin/bash "runner" \
 COPY --from=install /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=install ./runner /home/runner
 
-# install libicu for Ubuntu 25.04
+# Install libicu for GitHub Actions runner compatibility and apply security updates
 # https://github.com/actions/runner/issues/3150
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     libicu-dev \
-    && rm -rf /var/lib/apt/lists
+    && apt-get upgrade -y \
+    && rm -rf /var/lib/apt/lists/*
 
 # install runner dependencies
 RUN /home/runner/bin/installdependencies.sh

--- a/latest.Dockerfile
+++ b/latest.Dockerfile
@@ -23,6 +23,13 @@ RUN groupadd "runner" && useradd -g "runner" --shell /bin/bash "runner" \
 COPY --from=install /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=install ./runner /home/runner
 
+# Install libicu for GitHub Actions runner compatibility and apply security updates
+# https://github.com/actions/runner/issues/3150
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    libicu-dev \
+    && rm -rf /var/lib/apt/lists/*
+
 # install runner dependencies
 RUN /home/runner/bin/installdependencies.sh
 

--- a/latest.Dockerfile
+++ b/latest.Dockerfile
@@ -28,7 +28,6 @@ COPY --from=install ./runner /home/runner
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     libicu-dev \
-    && apt-get upgrade -y \
     && rm -rf /var/lib/apt/lists/*
 
 # install runner dependencies

--- a/latest.Dockerfile
+++ b/latest.Dockerfile
@@ -23,13 +23,6 @@ RUN groupadd "runner" && useradd -g "runner" --shell /bin/bash "runner" \
 COPY --from=install /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=install ./runner /home/runner
 
-# Install libicu for GitHub Actions runner compatibility and apply security updates
-# https://github.com/actions/runner/issues/3150
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-    libicu-dev \
-    && rm -rf /var/lib/apt/lists/*
-
 # install runner dependencies
 RUN /home/runner/bin/installdependencies.sh
 

--- a/playwright.Dockerfile
+++ b/playwright.Dockerfile
@@ -33,7 +33,6 @@ RUN apt-get update \
     jq \
     uuid-runtime \
     unzip \
-    && apt-get upgrade -y \
     && rm -rf /var/lib/apt/lists
 
 # install awscli because the standard runner has it

--- a/playwright.Dockerfile
+++ b/playwright.Dockerfile
@@ -33,6 +33,7 @@ RUN apt-get update \
     jq \
     uuid-runtime \
     unzip \
+    && apt-get upgrade -y \
     && rm -rf /var/lib/apt/lists
 
 # install awscli because the standard runner has it


### PR DESCRIPTION
T-MSIS consumes the image generated from `latest.Dockerfile`, and they scan for MEDIUM findings with Trivy. We should also scan at this level or else they will be complaining about findings that we don't see in our CI. But we don't want to scan for MEDIUM findings for the `playwright.Dockerfile` image for now, since we aren't free to upgrade the base image without a lot of work (since our CI is hardcoded to use Playwright 1.38.0 This change: 

- bumps `latest` to Ubuntu 25.10 to fix findings
- updates workflows to add scanning for MEDIUM findings for the latest image

Testing: 
- built and scanned the images locally
