### PR TITLE
Add version consistency to container definition

### DIFF
--- a/github-actions-runner-terraform/container-definitions.tpl
+++ b/github-actions-runner-terraform/container-definitions.tpl
@@ -2,6 +2,7 @@
   {
     "name": "gh-runner-${gh_name_hash}",
     "image": "${ecr_repo_url}:${ecr_repo_tag}",
+    "versionConsistency": "disabled",
     "cpu": ${container_cpu},
     "memory": ${container_memory},
     "essential": true,


### PR DESCRIPTION
This change fixes a bug. Once in the past, GitHub deprecated our runner version and stopped accepting jobs from it (GitHub aggressively deprecates older runner versions, sometimes immediately when new versions are released). Our GitHub Actions runners broke even after we pushed a new runner image with the new runner version, because AWS ECS caches the old container image when we push updates to the same tag, requiring manual forced deployments to pick up changes. This is a feature called [versionConsistency](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ContainerDefinition.html#:~:text=Required%3A%20No-,versionConsistency,-Specifies%20whether%20Amazon) that can be disabled. We push to the same tag because we have external consumers of the image that pull it to get the latest GitHub Actions runner software

Testing: 
- updated the module reference in the Dev Portal repo and confirmed that the `terraform plan` output showed the expected change to the container definition