### PR TITLE
[CMCSMACD-4229] add apt-get upgrade to dockerfile, add cron schedule to build-and-push workflow

### DIFF
--- a/.dockerfilelintrc
+++ b/.dockerfilelintrc
@@ -1,3 +1,4 @@
 rules:
   # This is needed because Dockle checks for `rm -rf /var/lib/apt/lists` while dockerfilelint checks for `rm -rf /var/lib/apt/lists/*`. We are choosing Dockle.
   apt-get_missing_rm: off
+  apt-get-upgrade: off

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches-ignore:
       - "*-skip-build"
+  schedule:
+    - cron: "0 8 * * 1" # every Monday at 8am
 
 permissions:
   id-token: write

--- a/.trivyignore-latest
+++ b/.trivyignore-latest
@@ -1,6 +1,3 @@
 # accept the risk of the internal Node.JS libraries used by the runner.
 
 CVE-2024-21538
-
-
-

--- a/latest.Dockerfile
+++ b/latest.Dockerfile
@@ -34,8 +34,9 @@ RUN apt-get update && \
 RUN /home/runner/bin/installdependencies.sh
 
 # install entrypoint.sh dependencies (separately since these change more often)
-RUN apt-get update \
-    && apt-get -qq -y install --no-install-recommends \
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get -qq -y install --no-install-recommends \
     curl \
     jq \
     uuid-runtime \


### PR DESCRIPTION
https://jiraent.cms.gov/browse/CMCSMACD-4229

Added a cron schedule trigger to `build-and-push.yml` to run every Monday morning at 8am.

**Tested:**
- Rebuilt docker image and ran a trivy scan on it. No additional vulnerabilities were found.