### PR TITLE
use aws_region.current.region

### DIFF
--- a/github-actions-runner-terraform/cloudwatch.tf
+++ b/github-actions-runner-terraform/cloudwatch.tf
@@ -48,7 +48,7 @@ data "aws_iam_policy_document" "cloudwatch_logs_allow_kms" {
 
     principals {
       type        = "Service"
-      identifiers = ["logs.${data.aws_region.current.name}.amazonaws.com"]
+      identifiers = ["logs.${data.aws_region.current.region}.amazonaws.com"]
     }
 
     actions = [
@@ -65,7 +65,7 @@ data "aws_iam_policy_document" "cloudwatch_logs_allow_kms" {
       variable = "kms:EncryptionContext:aws:logs:arn"
 
       values = [
-        "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/ecs/${var.environment}/gh-runner*",
+        "arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:/ecs/${var.environment}/gh-runner*",
       ]
     }
   }

--- a/github-actions-runner-terraform/ecs.tf
+++ b/github-actions-runner-terraform/ecs.tf
@@ -154,7 +154,7 @@ data "aws_iam_policy_document" "task_role_policy_doc" {
       "secretsmanager:GetSecretValue",
     ]
     resources = [
-      "arn:${data.aws_partition.current.partition}:secretsmanager:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:secret:/github-runner*",
+      "arn:${data.aws_partition.current.partition}:secretsmanager:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:secret:/github-runner*",
     ]
   }
 
@@ -164,7 +164,7 @@ data "aws_iam_policy_document" "task_role_policy_doc" {
     ]
 
     resources = [
-      "arn:${data.aws_partition.current.partition}:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter/github-runner*"
+      "arn:${data.aws_partition.current.partition}:ssm:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:parameter/github-runner*"
     ]
   }
 }
@@ -206,7 +206,7 @@ resource "aws_ecs_task_definition" "runner_def" {
       ecr_repo_url              = var.ecr_repo_url,
       ecr_repo_tag              = var.ecr_repo_tag,
       awslogs_group             = local.awslogs_group,
-      awslogs_region            = data.aws_region.current.name,
+      awslogs_region            = data.aws_region.current.region,
       personal_access_token_arn = var.personal_access_token_arn,
       github_repo_owner         = var.github_repo_owner,
       github_repo_name          = var.github_repo_name,

--- a/github-actions-runner-terraform/versions.tf
+++ b/github-actions-runner-terraform/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = ">= 6.0"
     }
   }
 }

--- a/github-actions-runner-terraform/versions.tf
+++ b/github-actions-runner-terraform/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0"
+      version = "~> 6.0"
     }
   }
 }


### PR DESCRIPTION
https://jiraent.cms.gov/browse/CMCSMACD-4635
PR Description
Change aws_region.name to aws_region.region per [docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region#argument-reference)
I updated the minimum aws provider version required by this module is `>= 5.0`

Tested:
I updated the aws provider in teams-api to with aws provider `~> 6.0` and referenced this module:
`source = "github.com/Enterprise-CMCS/mac-fc-github-actions-runner-aws//github-actions-runner-terraform?ref=lbk/create-version-7"`
I successfully ran `terraform plan` in teams-api/terraform/dev,prod and got back No changes, as expected.

